### PR TITLE
fixed typo in content url's

### DIFF
--- a/frontend/content/resources/bump-cdk-github-action/index.yml
+++ b/frontend/content/resources/bump-cdk-github-action/index.yml
@@ -1,6 +1,6 @@
 title: Bump CDK (Github Action)
 teaser: GitHub Action for automating cdk version management
-url: https://github.com/cdk-dev/bump-cdk-action"
+url: "https://github.com/cdk-dev/bump-cdk-action"
 createdAt: "2020-09-17 20:05"
 categories:
   - Tools

--- a/frontend/content/resources/bump-cdk/index.yml
+++ b/frontend/content/resources/bump-cdk/index.yml
@@ -1,6 +1,6 @@
 title: Bump CDK
 teaser: Easily manage AWS CDK Dependencies
-url: https://github.com/cdk-dev/bump-cdk"
+url: "https://github.com/cdk-dev/bump-cdk"
 createdAt: "2020-09-17 20:06"
 categories:
   - Tools

--- a/frontend/content/resources/create-cdk-app/index.yml
+++ b/frontend/content/resources/create-cdk-app/index.yml
@@ -1,6 +1,6 @@
 title: Create CDK App
 teaser: Create CDK apps from templates
-url: https://github.com/cdk-dev/create-cdk-app"
+url: "https://github.com/cdk-dev/create-cdk-app"
 createdAt: "2020-09-17 20:04"
 categories:
   - Tools


### PR DESCRIPTION
*Issue #, if available:* Links didn't open

*Description of changes:* Fixed by adding missing double quote's


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
