### PR TITLE
Replace expired invite link

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -49,7 +49,7 @@ function Footer(): ReactElement {
         </nav>
         <div className="mt-8 flex justify-center">
           <a
-            href="https://cdk-dev.slack.com/join/shared_invite/zt-gff3dtkw-MsEPa5Id1Aey8HQUDEck1Q#/"
+            href="https://join.slack.com/t/cdk-dev/shared_invite/zt-mso6p56d-qJp7SOTBvMaQuDrx7R2wHg"
             className="text-gray-400 hover:text-gray-500"
           >
             <span className="sr-only">Slack</span>

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -259,7 +259,7 @@ function Nav({ title }: NavProps): ReactElement {
               <div className="mt-5 max-w-md mx-auto sm:flex sm:justify-center md:mt-8">
                 <div className="rounded-md shadow">
                   <a
-                    href="https://cdk-dev.slack.com/join/shared_invite/zt-gff3dtkw-MsEPa5Id1Aey8HQUDEck1Q#/"
+                    href="https://join.slack.com/t/cdk-dev/shared_invite/zt-mso6p56d-qJp7SOTBvMaQuDrx7R2wHg"
                     className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo transition duration-150 ease-in-out md:py-4 md:text-lg md:px-10"
                   >
                     Join Slack


### PR DESCRIPTION
Apparently, invite links expire after 2000 people joined, even though
it's not expiring after a certain time.
