### PR TITLE
Fix small typo on front page

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -20,7 +20,7 @@ const Index = ({ posts }) => (
             Recent Community Blog Posts
           </h2>
           <p className="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
-            What's been talked about in the CDK ecosytem.{" "}
+            What's being talked about in the CDK ecosystem.{" "}
             <a className="italic underline" href="/posts">
               More...
             </a>


### PR DESCRIPTION
I can raise an issue if desired, this seemed small enough not to need one.

*Description of changes:*
Just a quick typo fix, and a slight rephrasing of the copy referring to the latest blog posts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
