### PR TITLE
add cicd slackbot and ephemeral stack posts

### DIFF
--- a/frontend/content/posts/cdk-slackbot-for-cicd/index.yml
+++ b/frontend/content/posts/cdk-slackbot-for-cicd/index.yml
@@ -1,0 +1,12 @@
+title: "From Code to Conversation: Bridging GitHub Actions and Slack with CDK"
+excerpt: "The Slack Integration Every Dev Team Needs"
+authorIds:
+  - matt-martz
+url: https://matt.martz.codes/cdk-slackbot
+createdAt: "2023-08-21 14:00"
+categories:
+  - AWS-CDK
+  - Lambda
+  - Typescript
+  - Github
+  - CI/CD

--- a/frontend/content/posts/destroy-their-stacks/index.yml
+++ b/frontend/content/posts/destroy-their-stacks/index.yml
@@ -1,0 +1,11 @@
+title: "Destroy THEIR Stacks - Ephemeral CDK Stacks as a Service"
+excerpt: "Ephemeral CDK Stacks as a Service"
+authorIds:
+  - matt-martz
+url: https://matt.martz.codes/destroy-their-stacks-ephemeral-cdk-stacks-as-a-service
+createdAt: "2023-06-29 14:00"
+categories:
+  - AWS-CDK
+  - Lambda
+  - Typescript
+  - CI/CD

--- a/frontend/content/users/matt-martz/index.yml
+++ b/frontend/content/users/matt-martz/index.yml
@@ -1,3 +1,4 @@
 name: Matt Martz
 avatar: cdkdevlogo.jpg
+twitter: martzcodes
 createdAt: "2021-01-04 10:00"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add two posts... one for a serverless Slack App that does CI/CD with GitHub Actions, and the other is for Ephemeral CDK Stacks as a Service
