### PR TITLE
feat: add two opensource cdk tools

### DIFF
--- a/frontend/content/resources/aws-cdk-starterkit/index.yml
+++ b/frontend/content/resources/aws-cdk-starterkit/index.yml
@@ -1,0 +1,9 @@
+title: AWS CDK Starterkit
+teaser: Create and deploy an AWS CDK app on your AWS account in less than 5 minutes using GitHub actions!
+url: "https://github.com/dannysteenman/aws-cdk-starterkit"
+createdAt: "2024-03-06 20:00"
+categories:
+  - Starterkit
+  - AWS CDK
+  - Examples
+  - Projen

--- a/frontend/content/resources/aws-cdk-starterkit/index.yml
+++ b/frontend/content/resources/aws-cdk-starterkit/index.yml
@@ -1,7 +1,7 @@
 title: AWS CDK Starterkit
 teaser: Create and deploy an AWS CDK app on your AWS account in less than 5 minutes using GitHub actions!
 url: "https://github.com/dannysteenman/aws-cdk-starterkit"
-createdAt: "2024-03-06 20:00"
+createdAt: "2024-03-12 06:00"
 categories:
   - Starterkit
   - AWS CDK

--- a/frontend/content/resources/vscode-cdk-snippets/index.yml
+++ b/frontend/content/resources/vscode-cdk-snippets/index.yml
@@ -1,0 +1,8 @@
+title: CDK Construct Snippets for VS Code
+teaser: This extension adds L1 construct snippets from AWS CDK into Visual Studio Code.
+url: "https://marketplace.visualstudio.com/items?itemName=dannysteenman.cdk-snippets"
+createdAt: "2021-05-04 20:00"
+categories:
+  - VS Code
+  - AWS CDK
+  - Snippets

--- a/frontend/content/resources/vscode-cdk-snippets/index.yml
+++ b/frontend/content/resources/vscode-cdk-snippets/index.yml
@@ -1,7 +1,7 @@
 title: CDK Construct Snippets for VS Code
 teaser: This extension adds L1 construct snippets from AWS CDK into Visual Studio Code.
 url: "https://marketplace.visualstudio.com/items?itemName=dannysteenman.cdk-snippets"
-createdAt: "2021-05-04 20:00"
+createdAt: "2024-03-11 09:00"
 categories:
   - VS Code
   - AWS CDK


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding 2 AWS CDK tools to the resource section of the cdk website:
- [AWS CDK Starterkit](https://github.com/dannysteenman/aws-cdk-starterkit) is a repository to get an AWS CDK app up and running in your AWS account in less than 5 minutes, leveraging GitHub Actions for seamless CI/CD.
- [CDK Construct Snippets for VS Code](https://marketplace.visualstudio.com/items?itemName=dannysteenman.cdk-snippets) is an extension that adds L1 construct snippets from AWS CDK into Visual Studio Code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
