### PR TITLE
fix: Updates Slack invite link

### DIFF
--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -57,7 +57,7 @@ function Footer(): ReactElement {
         </nav>
         <div className="mt-8 flex justify-center">
           <a
-            href="https://join.slack.com/t/cdk-dev/shared_invite/zt-2x11bis53-p6x9y~dL5TVAmPDUtP9ddw"
+            href="https://join.slack.com/t/cdk-dev/shared_invite/zt-3dr99fhxi-tLhK~kWLgxlLu6lIJaXvfg"
             className="text-gray-400 hover:text-gray-500"
           >
             <span className="sr-only">Slack</span>

--- a/app/_components/Hero.tsx
+++ b/app/_components/Hero.tsx
@@ -267,7 +267,7 @@ function Nav({ title }: NavProps): ReactElement {
               <div className="mt-5 max-w-md mx-auto sm:flex sm:justify-center md:mt-8">
                 <div className="rounded-md shadow">
                   <a
-                    href="https://join.slack.com/t/cdk-dev/shared_invite/zt-2x11bis53-p6x9y~dL5TVAmPDUtP9ddw"
+                    href="https://join.slack.com/t/cdk-dev/shared_invite/zt-3dr99fhxi-tLhK~kWLgxlLu6lIJaXvfg"
                     className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo transition duration-150 ease-in-out md:py-4 md:text-lg md:px-10"
                   >
                     Join Slack


### PR DESCRIPTION
Updates the Slack invite link in the footer and hero sections to point to the new workspace. This ensures users are directed to the correct community.

fixes #178

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
